### PR TITLE
Corrected Class comment link reference from 'Export' to Spring 'Exporter...

### DIFF
--- a/src/main/java/de/codecentric/batch/configuration/MetricsExporterConfiguration.java
+++ b/src/main/java/de/codecentric/batch/configuration/MetricsExporterConfiguration.java
@@ -36,7 +36,8 @@ import de.codecentric.batch.metrics.InfluxdbMetricsExporter;
 
 /**
  * Configuration for the Metrics Exporters. Actually Console, InfluxDB and Graphite are
- * supported. To add a new implementation just implement the generic {@link Export}
+ * supported. To add a new implementation just implement the generic
+ * {@link org.springframework.boot.actuate.metrics.export.Exporter}
  * interface for metric exports and register it as a Spring Bean.
  * 
  * @author Dennis Schulte


### PR DESCRIPTION
Hi,

When performing a 'mvn clean install' the build was failing with the error below. I've changed the incorrect comment 'link' reference to fix the issue :-)

Feel free to shout if you have any questions

Best wishes,

Daniel

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.8.1:jar (attach-javadocs) on project spring-boot-starter-batch-web: MavenReportException: Error while creating archive:
[ERROR] Exit code: 1 - /Users/danielbryant/Documents/dev/daniel-bryant-uk/spring-boot-starter-batch-web/src/main/java/de/codecentric/batch/configuration/MetricsExporterConfiguration.java:39: error: reference not found
[ERROR] * supported. To add a new implementation just implement the generic {@link Export}