### PR TITLE
Generate configuration-metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,11 @@
 			<artifactId>spring-boot-starter-aop</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-messaging</artifactId>
 		</dependency>

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -38,7 +38,7 @@ https://blog.codecentric.de/en/2014/11/enterprise-java-batch-best-practice-archi
 
 . If you have a database with the Spring Batch meta data tables and your business data, add the connection properties to the application.properties like in https://github.com/codecentric/spring-samples/blob/master/batch-boot-file-to-db/src/main/resources/application.properties[this example]. If you don't specify these properties you'll get an in-memory database for the Spring Batch meta data tables.
 . Add a simple logback.xml for logging. Here's an https://github.com/codecentric/spring-samples/blob/master/batch-boot-file-to-db/src/main/resources/logback.xml[example] inheriting from our basic log configuration to support log file separation.
-. Add a batch job. You may define it in XML and put it into META-INF/spring/batch/jobs (overridable via property batch.config.path.xml) or in JavaConfig and put it into the package spring.batch.jobs (overridable via property batch.config.package.javaconfig). Each XML file or class annotated with @Configuration in the specified locations will get its own child ApplicationContext. Third option is defining a JSR-352 style job in XML and adding it to META-INF/batch-jobs.
+. Add a batch job. You may define it in XML and put it into META-INF/spring/batch/jobs (overridable via property batch.config.path-xml) or in JavaConfig and put it into the package spring.batch.jobs (overridable via property batch.config.package-javaconfig). Each XML file or class annotated with @Configuration in the specified locations will get its own child ApplicationContext. Third option is defining a JSR-352 style job in XML and adding it to META-INF/batch-jobs.
 . Add an entry point to the application, a class with a main method invoking SpringApplication.run(...). Take a look at this https://github.com/codecentric/spring-samples/blob/master/batch-boot-simple/src/main/java/de/codecentric/batch/Application.java[example].
 . Build the application via maven package. Then start the application using java -jar xxx.jar.
 
@@ -51,57 +51,55 @@ There are two ways to influence spring-boot-starter-batch-web's behaviour. The f
 |===
 |Property name |Description |Default value
 
-|batch.config.path.xml 	 	
+|batch.config.path-xml
 |Location in the classpath where Spring Batch job definitions in XML are picked up.
-|/META-INF/spring/batch/jobs
+|`classpath*:/META-INF/spring/batch/jobs/*.xml`
 
-|batch.config. package.javaconfig
+|batch.config.package-javaconfig
 |Package where Spring Batch job definitions in JavaConfig are picked up.
-|spring.batch.jobs
+|`spring.batch.jobs`
 
-|batch.defaultprotocol. enabled
+|batch.default-protocol.enabled
 |Whether the default job protocol printed into the log is activated.
-|true
+|`true`
 
-|batch.logfileseparation. enabled
+|batch.logfile-separation.enabled
 |Whether writing one log file for each job execution is activated.
-|true
+|`true`
+
+|batch.joblog.path
+|Path where the separate logfiles are stored. Can be used as `JOB_LOG_PATH` in logback configuration.
+|
 
 |batch.metrics.enabled
 |Whether the transaction safe batch metrics framework is activated so that BatchMetrics may be injected and used.
-|false
+|`false`
 
-|batch.metrics.profiling. readprocesswrite.enabled
+|batch.metrics.profiling.readprocesswrite.enabled
 |Readers, Processors and Writers are profiled with RichGauges when set to true.
-|false
+|`false`
 
-|batch.core.pool.size
-|Core pool size of the thread pool.
-|5
+|batch.task-executor.*
+|Configure the used org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor instance
+|core-pool-size: 5 +
+max-pool-size: Integer.MAX_VALUE +
+queue-Capacity: Integer.MAX_VALUE +
 
-|batch.queue.capacity
-|Queue capacity of the task executor.
-|Integer.MAX_VALUE
-
-|batch.max.pool.size
-|Max pool size of the thread pool.
-|Integer.MAX_VALUE
-
-|batch.repository. isolationlevelforcreate
+|batch.repository.isolation-level-for-create
 |Database isolation level for creating job executions.
-|Spring Batch’s default
+|Spring Batch default
 
-|batch.repository. tableprefix
+|batch.repository.table-prefix
 |Prefix for Spring Batch meta data tables.
-|Not set
+|
 
-|batch.web.operations.base 	
+|batch.web.operations.base
 |Base URL for the operations endpoint.
-|/batch/operations
+|`/batch/operations`
 
 |batch.web.monitoring.base
 |Base URL for the monitoring endpoint.
-|/batch/monitoring
+|`/batch/monitoring`
 
 |===
 
@@ -146,7 +144,7 @@ start() {
   java -jar /opt/batch/example-batch/example-batch.jar >> /var/log/example-batch.log 2>&1 &
 }
 
-# Stopps the application
+# Stops the application
 stop() {
   [...]
 }

--- a/src/main/java/de/codecentric/batch/configuration/BatchConfigurationProperties.java
+++ b/src/main/java/de/codecentric/batch/configuration/BatchConfigurationProperties.java
@@ -1,0 +1,116 @@
+package de.codecentric.batch.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("batch")
+public class BatchConfigurationProperties {
+
+	/*
+	 * Configures the automatic registration of job configurations.
+	 */
+	private JobConfigurationProperties config = new JobConfigurationProperties();
+
+	/*
+	 * Enable printing of the the default job protocol to the logs.
+	 */
+	private Toggle defaultProtocol = new Toggle(true);
+
+	/*
+	 * Enable writing of a new logfile for each job execution.
+	 */
+	private Toggle logfileSeparation = new Toggle(true);
+
+	/*
+	 * Configures the jobReposiotry
+	 */
+	private RepositoryConfigurationProperties repository = new RepositoryConfigurationProperties();
+
+
+	public Toggle getDefaultProtocol() {
+		return defaultProtocol;
+	}
+
+	public Toggle getLogfileSeparation() {
+		return logfileSeparation;
+	}
+
+	public JobConfigurationProperties getConfig() {
+		return config;
+	}
+
+	public RepositoryConfigurationProperties getRepository() {
+		return repository;
+	}
+
+	public static class JobConfigurationProperties {
+		/*
+		 * Location in the classpath where Spring Batch job definitions in XML are picked
+		 * up.
+		 */
+		private String pathXml = "classpath*:/META-INF/spring/batch/jobs/*.xml";
+
+		/*
+		 * Package where Spring Batch job definitions in JavaConfig are picked up.
+		 */
+		private String packageJavaconfig = "spring.batch.jobs";
+
+		public void setPathXml(String pathXml) {
+			this.pathXml = pathXml;
+		}
+
+		public String getPathXml() {
+			return pathXml;
+		}
+
+		public void setPackageJavaconfig(String packageJavaconfig) {
+			this.packageJavaconfig = packageJavaconfig;
+		}
+
+		public String getPackageJavaconfig() {
+			return packageJavaconfig;
+		}
+
+	}
+
+	public static class RepositoryConfigurationProperties {
+		/*
+		 *
+		 */
+		private String isolationLevelForCreate = null;
+
+		/*
+		 *
+		 */
+		private String tablePrefix = null;
+
+		public void setIsolationLevelForCreate(String isolationLevelForCreate) {
+			this.isolationLevelForCreate = isolationLevelForCreate;
+		}
+
+		public String getIsolationLevelForCreate() {
+			return isolationLevelForCreate;
+		}
+
+		public void setTablePrefix(String tablePrefix) {
+			this.tablePrefix = tablePrefix;
+		}
+		public String getTablePrefix() {
+			return tablePrefix;
+		}
+
+	}
+
+	public static class Toggle {
+		private boolean enabled;
+		public Toggle(boolean enabled) {
+			this.enabled = enabled;
+		}
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+		public boolean isEnabled() {
+			return enabled;
+		}
+	}
+
+}

--- a/src/main/java/de/codecentric/batch/configuration/BatchWebAutoConfiguration.java
+++ b/src/main/java/de/codecentric/batch/configuration/BatchWebAutoConfiguration.java
@@ -21,6 +21,7 @@ import org.springframework.batch.core.job.AbstractJob;
 import org.springframework.batch.core.launch.NoSuchJobException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,7 +29,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.core.Ordered;
-import org.springframework.core.env.Environment;
 
 import de.codecentric.batch.listener.AddListenerToJobService;
 import de.codecentric.batch.listener.LoggingAfterJobListener;
@@ -62,10 +62,11 @@ import de.codecentric.batch.monitoring.RunningExecutionTracker;
 @AutoConfigureAfter({org.springframework.boot.actuate.autoconfigure.MetricRepositoryAutoConfiguration.class})
 @Import({ WebConfig.class, TaskExecutorBatchConfigurer.class, AutomaticJobRegistrarConfiguration.class, BaseConfiguration.class,
 		Jsr352BatchConfiguration.class, MetricsConfiguration.class, TaskExecutorConfiguration.class })
+@EnableConfigurationProperties({BatchConfigurationProperties.class})
 public class BatchWebAutoConfiguration implements ApplicationListener<ContextRefreshedEvent>, Ordered {
 
 	@Autowired
-	private Environment env;
+	private BatchConfigurationProperties batchConfig;
 
 	@Autowired
 	private BaseConfiguration baseConfig;
@@ -99,8 +100,8 @@ public class BatchWebAutoConfiguration implements ApplicationListener<ContextRef
 
 	@Bean
 	public AddListenerToJobService addListenerToJobService() {
-		boolean addProtocolListener = env.getProperty("batch.defaultprotocol.enabled", boolean.class, true);
-		boolean addLoggingListener = env.getProperty("batch.logfileseparation.enabled", boolean.class, true);
+		boolean addProtocolListener = batchConfig.getDefaultProtocol().isEnabled();
+		boolean addLoggingListener = batchConfig.getLogfileSeparation().isEnabled();
 		return new AddListenerToJobService(addProtocolListener, addLoggingListener, protocolListener(), runningExecutionTrackerListener(),
 				loggingListener(), loggingAfterJobListener());
 	}

--- a/src/main/java/de/codecentric/batch/configuration/TaskExecutorBatchConfigurer.java
+++ b/src/main/java/de/codecentric/batch/configuration/TaskExecutorBatchConfigurer.java
@@ -34,7 +34,6 @@ import org.springframework.batch.support.transaction.ResourcelessTransactionMana
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -43,11 +42,11 @@ import org.springframework.transaction.PlatformTransactionManager;
  * This batch infrastructure configuration is quite similar to the
  * {@link org.springframework.batch.core.configuration.annotation.DefaultBatchConfigurer}, it only
  * references a {@link org.springframework.core.task.TaskExecutor} used in the {@link org.springframework.batch.core.launch.support.SimpleJobLauncher}
- * for starting jobs asynchronously. 
- * 
+ * for starting jobs asynchronously.
+ *
  * @author Tobias Flohre
  * @author Dennis Schulte
- * 
+ *
  */
 @ConditionalOnMissingBean(BatchConfigurer.class)
 @Configuration
@@ -55,19 +54,20 @@ public class TaskExecutorBatchConfigurer implements BatchConfigurer {
 
 	private static final Log logger = LogFactory.getLog(TaskExecutorBatchConfigurer.class);
 
-	@Autowired
-	private Environment env;
-	
-	// Created by TaskExecutorConfiguration if it is used. If an alternative TaskExecutor is configured, 
+	// Created by TaskExecutorConfiguration if it is used. If an alternative TaskExecutor is configured,
 	// it will be injected here.
 	@Autowired
 	private TaskExecutor taskExecutor;
-	
+
+	@Autowired
+	private BatchConfigurationProperties batchConfig;
+
 	private DataSource dataSource;
 	private PlatformTransactionManager transactionManager;
 	private JobRepository jobRepository;
 	private JobLauncher jobLauncher;
 	private JobExplorer jobExplorer;
+
 
 	@Autowired
 	public void setDataSource(DataSource dataSource) {
@@ -107,16 +107,16 @@ public class TaskExecutorBatchConfigurer implements BatchConfigurer {
 		JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
 		factory.setDataSource(dataSource);
 		factory.setTransactionManager(transactionManager);
-		String isolationLevelForCreate = env.getProperty("batch.repository.isolationlevelforcreate");
+		String isolationLevelForCreate = batchConfig.getRepository().getIsolationLevelForCreate();
 		if (isolationLevelForCreate != null) {
 			factory.setIsolationLevelForCreate(isolationLevelForCreate);
 		}
-		String tablePrefix = env.getProperty("batch.repository.tableprefix");
+		String tablePrefix = batchConfig.getRepository().getTablePrefix();
 		if (tablePrefix != null) {
 			factory.setTablePrefix(tablePrefix);
 		}
 		factory.afterPropertiesSet();
-		return (JobRepository) factory.getObject();
+		return factory.getObject();
 	}
 
 	@PostConstruct

--- a/src/main/java/de/codecentric/batch/configuration/TaskExecutorConfiguration.java
+++ b/src/main/java/de/codecentric/batch/configuration/TaskExecutorConfiguration.java
@@ -15,11 +15,10 @@
  */
 package de.codecentric.batch.configuration;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
@@ -28,38 +27,35 @@ import de.codecentric.batch.scheduling.concurrent.MdcThreadPoolTaskExecutor;
 /**
  * This is the default configuration for a {@link org.springframework.core.task.TaskExecutor} used in the {@link org.springframework.batch.core.launch.support.SimpleJobLauncher}
  * for starting jobs asynchronously. Its core thread pool is configured to five threads by default, which can be changed
- * by setting the property batch.core.pool.size to a different number. 
- * 
+ * by setting the property batch.core.pool.size to a different number.
+ *
  * Please note the following rules of the ThreadPoolExecutor:
  * If the number of threads is less than the corePoolSize, the executor creates a new thread to run a new task.
  * If the number of threads is equal (or greater than) the corePoolSize, the executor puts the task into the queue.
  * If the queue is full and the number of threads is less than the maxPoolSize, the executor creates a new thread to run a new task.
  * If the queue is full and the number of threads is greater than or equal to maxPoolSize, reject the task.
- * 
+ *
  * So with the default configuration there will be only 5 jobs/threads at the same time.
- * 
+ *
  * The {@link org.springframework.core.task.TaskExecutor} may also be used in job configurations
  * for multi-threaded job execution. In XML you can use it by name, which is taskExecutor. In JavaConfig,
  * you can either autowire {@link org.springframework.core.task.TaskExecutor} or, if you want to know
  * where it's configured, this class.
- * 
+ *
  * @author Dennis Schulte
- * 
+ *
  */
 @Configuration
 @ConditionalOnMissingBean(TaskExecutor.class)
 public class TaskExecutorConfiguration {
-	
-	@Autowired
-	private Environment env;
-	
+
 	@Bean
-	public TaskExecutor taskExecutor() {
+	@ConfigurationProperties("batch.task-executor")
+	public ThreadPoolTaskExecutor taskExecutor() {
 		ThreadPoolTaskExecutor taskExecutor = new MdcThreadPoolTaskExecutor();
-		taskExecutor.setCorePoolSize(env.getProperty("batch.core.pool.size", Integer.class, 5));
-		taskExecutor.setQueueCapacity(env.getProperty("batch.queue.capacity", Integer.class, Integer.MAX_VALUE));
-		taskExecutor.setMaxPoolSize(env.getProperty("batch.max.pool.size", Integer.class, Integer.MAX_VALUE));
-		taskExecutor.afterPropertiesSet();
+		taskExecutor.setCorePoolSize(5);
+		taskExecutor.setQueueCapacity(Integer.MAX_VALUE);
+		taskExecutor.setMaxPoolSize(Integer.MAX_VALUE);
 		return taskExecutor;
 	}
 

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,37 @@
+{"properties": [
+  {
+    "name": "batch.metrics.enabled",
+    "type": "java.lang.Boolean",
+    "description": "Enable the transaction safe batch metrics framework",
+    "sourceType": "de.codecentric.batch.configuration.MetricsConfiguration",
+    "defaultValue": "false"
+  },
+  {
+    "name": "batch.metrics.profiling.readprocesswrite.enabled",
+    "type": "java.lang.Boolean",
+    "description": "Enables the profiling for readers, processors and writers using RichGauges",
+    "sourceType": "de.codecentric.batch.configuration.MetricsConfiguration",
+    "defaultValue": "false"
+  },
+  {
+    "name": "batch.web.operation.base",
+    "type": "java.lang.String",
+    "description": "Base URL for the operations endpoint",
+    "sourceType": "de.codecentric.batch.web.JobOperationsController",
+    "defaultValue": "/batch/operations"
+  },
+  {
+    "name": "batch.web.monitioring.base",
+    "type": "java.lang.String",
+    "description": "Base URL for the monitoring endpoint",
+    "sourceType": "de.codecentric.batch.web.JobMonitoringController",
+    "defaultValue": "/batch/monitoring"
+  },
+  {
+    "name": "batch.joblog.path",
+    "type": "java.lang.String",
+    "description": "Path where the separate logfiles are stored. Can be used as JOB_LOG_PATH in logback configuration.",
+    "sourceType": "de.codecentric.batch.listener.JobLoggingApplicationListener"
+  }
+]}
+

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,2 +1,2 @@
-batch.config.package.javaconfig=de.codecentric.batch.jobs
+batch.config.package-javaconfig=de.codecentric.batch.jobs
 logging.path=target/


### PR DESCRIPTION
Use @ConfigurationProperties so that metadata for the configuration options is
available and boots relaxed bindings can be used

This commit changes the semantics of batch.config.path-xml slightly as now the
full resource pattern, including 'classpath:' and '*.xml' has to be specified.

This commit renames some of the properties:
batch.config.path.xml --> batch.config.path-xml
batch.config.package.javaconfig --> batch.config.package-javaconfig
batch.defaultprotocol.enabled --> batch.default-protocol.enabled
batch.logfileseparation.enabled --> batch.logfile-separation.enabled
batch.core.pool.size --> batch.task-executor.core-pool-size
batch.max.pool.size --> batch.task-executor.max-pool-size
batch.queue.capacity --> batch.task-executor.queue-capacity
batch.repository.isolationlevelforcreate --> batch.repository.isolation-level-for-create
batch.repository.tableprefix --> batch.repository.table-prefix

Also Add the spring-boot-configuration-processor as optional dependency so that the
configuration-metadata will be generated.
