### PR TITLE
Fix message converter customization

### DIFF
--- a/src/main/java/de/codecentric/batch/configuration/WebConfig.java
+++ b/src/main/java/de/codecentric/batch/configuration/WebConfig.java
@@ -49,7 +49,7 @@ public class WebConfig extends WebMvcConfigurerAdapter {
 	private JsrJobOperator jsrJobOperator;
 
 	@Override
-	public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+	public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
 		for (HttpMessageConverter<?> httpMessageConverter : converters) {
 			if (httpMessageConverter instanceof MappingJackson2HttpMessageConverter) {
 				final MappingJackson2HttpMessageConverter converter = (MappingJackson2HttpMessageConverter) httpMessageConverter;


### PR DESCRIPTION
The original source uses the wrong method of WebMvcConfigurer interface to customize the message converters.